### PR TITLE
Improving performance when reading properties of paths repeatedly

### DIFF
--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -18,6 +18,13 @@ struct AzureReadOptions {
 	idx_t buffer_size = 1 * 1024 * 1024;
 };
 
+struct AzurePathMetadata {
+	time_t last_modified = 0;
+	idx_t file_size = 0;
+};
+
+using AzurePathMetadataCache = std::map<std::string, AzurePathMetadata>;
+
 class AzureContextState : public ClientContextState {
 public:
 	const AzureReadOptions read_options;
@@ -111,6 +118,12 @@ protected:
 
 	virtual void LoadRemoteFileInfo(AzureFileHandle &handle) = 0;
 	static AzureReadOptions ParseAzureReadOptions(optional_ptr<FileOpener> opener);
+
+	// Cache with metadata of paths, this is useful for performance to avoid making
+	// multiple requests to the Azure service for getting properties of same path.
+	AzurePathMetadataCache path_metadata_cache;
+
+public:
 	static time_t ToTimeT(const Azure::DateTime &dt);
 };
 


### PR DESCRIPTION
This PR improves the performance when code base reads the properties of paths.

The code in the extension makes one request for listing all files matching the given path with wildcards + N requests for reading the necessary parquet files (N x M times, N parquets, M threads).

The code then creates as many [AzureFileHandle](https://github.com/duckdb/duckdb-azure/blob/main/src/azure_dfs_filesystem.cpp#L97) instances as MxN requests. 

So this [function](https://github.com/duckdb/duckdb-azure/blob/main/src/azure_dfs_filesystem.cpp#L111) is critical to get the best perfomance as possible. This function finally gets the [properties](https://github.com/duckdb/duckdb-azure/blob/main/src/azure_dfs_filesystem.cpp#L168) of a path (FileSize, LastModified) to be used later.

The "innocent" GetProperties is a big bottleneck in the performance, and we could avoid it just caching that metadata in the first [request](https://github.com/duckdb/duckdb-azure/blob/main/src/azure_dfs_filesystem.cpp#L121) for listing all files matching the given path.

The gain of performance is huge when query has to open many parquets and core is using many threads (20 by default).

