### PR TITLE
add [V]FS primitive FileExists support to Azure ADLS2/DFS

### DIFF
--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -179,13 +179,12 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 }
 
 bool AzureBlobStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
-	try {
-		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
-		auto &sfh = handle->Cast<AzureBlobStorageFileHandle>();
-		return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
-	} catch (...) {
-		return false;
-	};
+  auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
+  if (handle != nullptr) {
+    auto &sfh = handle->Cast<AzureBlobStorageFileHandle>();
+    return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
+  }
+  return false;
 }
 
 void AzureBlobStorageFileSystem::ReadRange(AzureFileHandle &handle, idx_t file_offset, char *buffer_out,

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -180,12 +180,9 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 
 bool AzureBlobStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
 	try {
-		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
+		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
 		auto &sfh = handle->Cast<AzureBlobStorageFileHandle>();
-		if (sfh.length == 0) {
-			return false;
-		}
-		return true;
+		return sfh.length >= 0; // avoid optimizers and shenanigans -- deref the handle to be sure
 	} catch (...) {
 		return false;
 	};

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -182,7 +182,7 @@ bool AzureBlobStorageFileSystem::FileExists(const string &filename, optional_ptr
 	try {
 		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
 		auto &sfh = handle->Cast<AzureBlobStorageFileHandle>();
-		return sfh.length >= 0; // avoid optimizers and shenanigans -- deref the handle to be sure
+		return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
 	} catch (...) {
 		return false;
 	};

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -129,7 +129,7 @@ bool AzureDfsStorageFileSystem::FileExists(const string &filename, optional_ptr<
 	try {
 		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
 		auto &sfh = handle->Cast<AzureDfsStorageFileHandle>();
-		return sfh.length >= 0; // avoid optimizers and shenanigans -- deref the handle to be sure
+		return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
 	} catch (...) {
 		return false;
 	};

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -126,13 +126,12 @@ bool AzureDfsStorageFileSystem::CanHandleFile(const string &fpath) {
 }
 
 bool AzureDfsStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
-	try {
-		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
-		auto &sfh = handle->Cast<AzureDfsStorageFileHandle>();
-		return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
-	} catch (...) {
-		return false;
-	};
+  auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
+  if (handle != nullptr) {
+    auto &sfh = handle->Cast<AzureDfsStorageFileHandle>();
+    return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
+  }
+  return false;
 }
 
 vector<OpenFileInfo> AzureDfsStorageFileSystem::Glob(const string &path, FileOpener *opener) {

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -125,6 +125,16 @@ bool AzureDfsStorageFileSystem::CanHandleFile(const string &fpath) {
 	return IsDfsScheme(fpath);
 }
 
+bool AzureDfsStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
+	try {
+		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
+		auto &sfh = handle->Cast<AzureDfsStorageFileHandle>();
+		return sfh.length >= 0; // avoid optimizers and shenanigans -- deref the handle to be sure
+	} catch (...) {
+		return false;
+	};
+}
+
 vector<OpenFileInfo> AzureDfsStorageFileSystem::Glob(const string &path, FileOpener *opener) {
 	if (opener == nullptr) {
 		throw InternalException("Cannot do Azure storage Glob without FileOpener");

--- a/src/include/azure_dfs_filesystem.hpp
+++ b/src/include/azure_dfs_filesystem.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+
 #include <azure/storage/files/datalake/datalake_file_client.hpp>
 #include <azure/storage/files/datalake/datalake_file_system_client.hpp>
 #include <azure/storage/files/datalake/datalake_service_client.hpp>
@@ -44,6 +45,8 @@ public:
 	string GetName() const override {
 		return "AzureDfsStorageFileSystem";
 	}
+
+	bool FileExists(const string &filename, optional_ptr<FileOpener> opener) override;
 
 	// From AzureFilesystem
 	void LoadRemoteFileInfo(AzureFileHandle &handle) override;

--- a/test/sql/azure_vfs_ops.test
+++ b/test/sql/azure_vfs_ops.test
@@ -1,0 +1,47 @@
+
+# name: test/sql/azure_vfs_ops.test
+# description: test azure extension vfs ops
+# group: [azure]
+
+# Require statement will ensure this test is run with this extension loaded
+require azure
+
+require-env AZURE_STORAGE_CONNECTION_STRING
+
+# This test only confirms that FileExists gets called (not whether it's correct),
+# in response to Issue#68 -- Since Azurite doesn't support DFS there's no local
+# way to test it.
+
+# Set connection string from env var
+statement ok
+SET azure_storage_connection_string = '${AZURE_STORAGE_CONNECTION_STRING}';
+
+# NOTE: previous output, only on DFS since the container check comes from within FileExists calls:
+# D INSTALL 'abfss://foo/bar/go.duckdb_extension';
+# Not implemented Error:
+# AzureDfsStorageFileSystem: FileExists is not implemented!
+#
+# Getting output that container doesn't exist/invalid storage account confirms entry into FileExists call.
+
+statement error
+INSTALL 'az://invalid-container/dir/ext.duckdb_extension';
+----
+container does not exist
+
+
+statement error
+INSTALL 'abfss://invalid-container/dir/ext.duckdb_extension';
+----
+Cannot identify the storage account
+
+
+# NOTE: now test actual existance in az:// only -- abfss:// can only be a cloud test
+statement error
+INSTALL 'az://testing-public/non-existent.duckdb_extension';
+----
+blob does not exist
+
+statement error
+INSTALL 'az://testing-public/l.csv';
+----
+file is not a DuckDB extension


### PR DESCRIPTION
this already exists in Blob storage; however there appears to be a minor
bug where an existing file of "length == 0" would "not exist"; correct
this as well.

for #68 
