### PR TITLE
Fix intermittent unauthenticated requests when secret lookup races with temporary secret registration

### DIFF
--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -143,6 +143,7 @@ unique_ptr<AzureFileHandle> AzureBlobStorageFileSystem::CreateHandle(const OpenF
 
 	auto handle =
 	    make_uniq<AzureBlobStorageFileHandle>(*this, info, flags, storage_context->options, std::move(blob_client));
+	handle->connected_anonymously = storage_context->connected_anonymously;
 	if (!handle->PostConstruct()) {
 		return nullptr;
 	}
@@ -433,7 +434,11 @@ shared_ptr<AzureContextState> AzureBlobStorageFileSystem::CreateStorageContext(o
                                                                                const AzureParsedUrl &parsed_url) {
 	auto azure_options = ParseAzureOptions(opener);
 
-	return make_shared_ptr<AzureBlobContextState>(ConnectToBlobStorageAccount(opener, path, parsed_url), azure_options);
+	bool connected_anonymously = false;
+	auto state = make_shared_ptr<AzureBlobContextState>(
+	    ConnectToBlobStorageAccount(opener, path, parsed_url, &connected_anonymously), azure_options);
+	state->connected_anonymously = connected_anonymously;
+	return state;
 }
 
 int64_t AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -176,6 +176,7 @@ unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFi
 
 	auto handle = make_uniq<AzureDfsStorageFileHandle>(*this, info, flags, storage_context->options,
 	                                                   file_system_client.GetFileClient(file_path));
+	handle->connected_anonymously = storage_context->connected_anonymously;
 	if (!handle->PostConstruct()) {
 		return nullptr;
 	}
@@ -394,7 +395,11 @@ shared_ptr<AzureContextState> AzureDfsStorageFileSystem::CreateStorageContext(op
                                                                               const AzureParsedUrl &parsed_url) {
 	auto azure_options = ParseAzureOptions(opener);
 
-	return make_shared_ptr<AzureDfsContextState>(ConnectToDfsStorageAccount(opener, path, parsed_url), azure_options);
+	bool connected_anonymously = false;
+	auto state = make_shared_ptr<AzureDfsContextState>(
+	    ConnectToDfsStorageAccount(opener, path, parsed_url, &connected_anonymously), azure_options);
+	state->connected_anonymously = connected_anonymously;
+	return state;
 }
 
 int64_t AzureDfsStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -78,9 +78,15 @@ bool AzureStorageFileSystem::LoadFileInfo(AzureFileHandle &handle) {
 		if (int(e.StatusCode) == 404 && handle.flags.ReturnNullIfNotExists()) {
 			return false;
 		}
+		string hint;
+		if (handle.connected_anonymously && (int(e.StatusCode) == 401 || int(e.StatusCode) == 403)) {
+			hint = " The request was sent without authentication because no azure secret matched this path. If the "
+			       "storage account is not public, create an azure secret (CREATE SECRET ... TYPE azure ...) whose "
+			       "SCOPE covers this path, or check the scope of the existing secrets.";
+		}
 		throw IOException(
-		    "AzureStorageFileSystem open file '%s' failed with code '%s', Reason Phrase: '%s', Message: '%s'",
-		    handle.path, e.ErrorCode, e.ReasonPhrase, e.Message);
+		    "AzureStorageFileSystem open file '%s' failed with code '%s', Reason Phrase: '%s', Message: '%s'%s",
+		    handle.path, e.ErrorCode, e.ReasonPhrase, e.Message, hint);
 	} catch (const IOException &e) {
 		throw;
 	} catch (const std::exception &e) {
@@ -207,7 +213,7 @@ int64_t AzureStorageFileSystem::Read(FileHandle &handle, void *buffer, int64_t n
 	return nr_bytes;
 }
 
-static string GetContextKeyPath(optional_ptr<FileOpener> opener, const string &path, const AzureParsedUrl &parsed) {
+static string GetContextKeyPath(SecretMatch &secret_match, const AzureParsedUrl &parsed) {
 	// context key == proto://{storage_account}{.}{endpoint}
 	// when storage account / endpoint unavailable, try to fetch via secret manager
 	string account;
@@ -218,7 +224,6 @@ static string GetContextKeyPath(optional_ptr<FileOpener> opener, const string &p
 		endpoint = parsed.endpoint;
 	} else {
 		// no storage account? map it from the secret if possible
-		auto secret_match = LookupSecret(opener, path);
 		if (secret_match.HasMatch()) {
 			const auto &secret = dynamic_cast<const KeyValueSecret &>(secret_match.GetSecret());
 
@@ -245,6 +250,14 @@ static string GetContextKeyPath(optional_ptr<FileOpener> opener, const string &p
 	return has_account ? account : endpoint;
 }
 
+static string GetContextCredentialKey(SecretMatch &secret_match) {
+	if (secret_match.HasMatch()) {
+		const auto &secret = secret_match.GetSecret();
+		return secret.GetName() + "/" + secret.GetProvider();
+	}
+	return "anonymous";
+}
+
 shared_ptr<AzureContextState> AzureStorageFileSystem::GetOrCreateStorageContext(optional_ptr<FileOpener> opener,
                                                                                 const string &path,
                                                                                 const AzureParsedUrl &parsed_url) {
@@ -257,12 +270,16 @@ shared_ptr<AzureContextState> AzureStorageFileSystem::GetOrCreateStorageContext(
 
 	shared_ptr<AzureContextState> result;
 	if (azure_context_caching && client_context) {
-		string key_path = GetContextKeyPath(opener, path, parsed_url);
+		auto secret_match = LookupSecret(opener, path);
+		string key_path = GetContextKeyPath(secret_match, parsed_url);
 		auto &registered_state = client_context->registered_state;
 
 		// Ok, now use account in key, or otherwise skip the cache
 		if (!key_path.empty()) {
-			auto context_key = GetContextPrefix() + key_path;
+			// Include the credential identity in the key: a client created for the same storage account
+			// under a different credential (e.g. anonymous, or another secret vended for a different
+			// table) must not be reused for this path.
+			auto context_key = GetContextPrefix() + key_path + "#" + GetContextCredentialKey(secret_match);
 			result = registered_state->Get<AzureContextState>(context_key);
 			if (!result || !result->IsValid()) {
 				result = CreateStorageContext(opener, path, parsed_url);

--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -29,9 +29,11 @@
 #include <azure/storage/blobs/blob_service_client.hpp>
 #include <azure/storage/files/datalake/datalake_options.hpp>
 #include <azure/storage/files/datalake/datalake_service_client.hpp>
+#include <chrono>
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <thread>
 #include <type_traits>
 
 namespace duckdb {
@@ -651,7 +653,8 @@ static Azure::Core::Http::Policies::TransportOptions GetTransportOptions(optiona
 
 static Azure::Storage::Blobs::BlobServiceClient GetBlobStorageAccountClient(optional_ptr<FileOpener> opener,
                                                                             const std::string &provided_storage_account,
-                                                                            const std::string &provided_endpoint) {
+                                                                            const std::string &provided_endpoint,
+                                                                            bool *connected_anonymously) {
 	auto transport_options = GetTransportOptions(opener);
 	auto blob_options = ToBlobClientOptions(transport_options, opener);
 
@@ -691,6 +694,9 @@ static Azure::Storage::Blobs::BlobServiceClient GetBlobStorageAccountClient(opti
 	}
 
 	// Anonymous
+	if (connected_anonymously) {
+		*connected_anonymously = true;
+	}
 	return Azure::Storage::Blobs::BlobServiceClient {account_url, blob_options};
 }
 
@@ -702,26 +708,64 @@ const SecretMatch LookupSecret(optional_ptr<FileOpener> opener, const std::strin
 		return secret_manager->LookupSecret(*transaction, path, "azure");
 	}
 
+	// Some openers expose a ClientContext but no DatabaseInstance (e.g. openers coming from scan threads),
+	// in which case TryGetSecretManager returns nothing. Derive the secret manager and a system transaction
+	// from the context so (temporary) secrets are still found instead of silently connecting anonymously.
+	auto context = FileOpener::TryGetClientContext(opener);
+	if (context) {
+		auto system_transaction = CatalogTransaction::GetSystemCatalogTransaction(*context);
+		return SecretManager::Get(*context).LookupSecret(system_transaction, path, "azure");
+	}
+
 	return {};
+}
+
+static bool SecretLookupPossible(optional_ptr<FileOpener> opener) {
+	if (FileOpener::TryGetSecretManager(opener) && FileOpener::TryGetCatalogTransaction(opener)) {
+		return true;
+	}
+	return FileOpener::TryGetClientContext(opener) != nullptr;
+}
+
+// Temporary secrets can be registered concurrently with the first file opens (e.g. iceberg catalogs
+// registering vended per-table credentials at bind time while scan threads already open manifests) and
+// a just-created catalog entry only becomes visible to other transactions once it commits. Retry the
+// lookup briefly before concluding that there is no secret.
+static SecretMatch LookupSecretWithRetry(optional_ptr<FileOpener> opener, const std::string &path) {
+	auto secret_match = LookupSecret(opener, path);
+	if (secret_match.HasMatch() || !SecretLookupPossible(opener)) {
+		return secret_match;
+	}
+	static constexpr int RETRY_DELAYS_MS[] = {10, 25, 50, 100};
+	for (auto delay : RETRY_DELAYS_MS) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+		secret_match = LookupSecret(opener, path);
+		if (secret_match.HasMatch()) {
+			return secret_match;
+		}
+	}
+	return secret_match;
 }
 
 Azure::Storage::Blobs::BlobServiceClient ConnectToBlobStorageAccount(optional_ptr<FileOpener> opener,
                                                                      const std::string &path,
-                                                                     const AzureParsedUrl &azure_parsed_url) {
-	auto secret_match = LookupSecret(opener, path);
+                                                                     const AzureParsedUrl &azure_parsed_url,
+                                                                     bool *connected_anonymously) {
+	auto secret_match = LookupSecretWithRetry(opener, path);
 	if (secret_match.HasMatch()) {
 		const auto &base_secret = secret_match.GetSecret();
 		return GetBlobStorageAccountClient(opener, dynamic_cast<const KeyValueSecret &>(base_secret), azure_parsed_url);
 	}
 
 	// No secret found try to connect with variables
-	return GetBlobStorageAccountClient(opener, azure_parsed_url.storage_account_name, azure_parsed_url.endpoint);
+	return GetBlobStorageAccountClient(opener, azure_parsed_url.storage_account_name, azure_parsed_url.endpoint,
+	                                   connected_anonymously);
 }
 
 Azure::Storage::Files::DataLake::DataLakeServiceClient
 ConnectToDfsStorageAccount(optional_ptr<FileOpener> opener, const std::string &path,
-                           const AzureParsedUrl &azure_parsed_url) {
-	auto secret_match = LookupSecret(opener, path);
+                           const AzureParsedUrl &azure_parsed_url, bool *connected_anonymously) {
+	auto secret_match = LookupSecretWithRetry(opener, path);
 	if (secret_match.HasMatch()) {
 		const auto &base_secret = secret_match.GetSecret();
 		return GetDfsStorageAccountClient(opener, dynamic_cast<const KeyValueSecret &>(base_secret), azure_parsed_url);
@@ -735,6 +779,9 @@ ConnectToDfsStorageAccount(optional_ptr<FileOpener> opener, const std::string &p
 	}
 
 	// No secret but FQDN has been provided, connect to a public storage account
+	if (connected_anonymously) {
+		*connected_anonymously = true;
+	}
 	auto transport_options = GetTransportOptions(opener);
 	auto account_url = "https://" + azure_parsed_url.storage_account_name + '.' + azure_parsed_url.endpoint;
 	auto dfs_options = ToDfsClientOptions(transport_options, opener);

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -30,6 +30,8 @@ struct AzureOptions {
 class AzureContextState : public ClientContextState {
 public:
 	const AzureOptions options;
+	// True when no secret matched the path and the service client sends unauthenticated requests
+	bool connected_anonymously = false;
 
 public:
 	virtual bool IsValid() const;
@@ -73,6 +75,9 @@ protected:
 
 public:
 	FileOpenFlags flags;
+
+	// True when the underlying client sends unauthenticated requests (no secret matched the path)
+	bool connected_anonymously = false;
 
 	// File info
 	bool is_remote_loaded;

--- a/src/include/azure_storage_account_client.hpp
+++ b/src/include/azure_storage_account_client.hpp
@@ -12,13 +12,16 @@
 
 namespace duckdb {
 
+// When provided, `connected_anonymously` is set to true if no secret matched the path and the returned
+// client sends unauthenticated requests (public storage account access).
 Azure::Storage::Blobs::BlobServiceClient ConnectToBlobStorageAccount(optional_ptr<FileOpener> opener,
                                                                      const std::string &path,
-                                                                     const AzureParsedUrl &azure_parsed_url);
+                                                                     const AzureParsedUrl &azure_parsed_url,
+                                                                     bool *connected_anonymously = nullptr);
 
 Azure::Storage::Files::DataLake::DataLakeServiceClient
 ConnectToDfsStorageAccount(optional_ptr<FileOpener> opener, const std::string &path,
-                           const AzureParsedUrl &azure_parsed_url);
+                           const AzureParsedUrl &azure_parsed_url, bool *connected_anonymously = nullptr);
 
 const SecretMatch LookupSecret(optional_ptr<FileOpener> opener, const std::string &path);
 } // namespace duckdb

--- a/test/sql/azure_secret_per_credential_cache.test
+++ b/test/sql/azure_secret_per_credential_cache.test
@@ -1,0 +1,48 @@
+# name: test/sql/azure_secret_per_credential_cache.test
+# description: two secrets scoped to different containers of the same storage account must both work
+#              within a single query (the storage context cache is keyed per credential, not only per account)
+# group: [sql]
+
+require azure
+
+require parquet
+
+require-env AZURE_STORAGE_CONNECTION_STRING
+
+require-env AZ_STORAGE_ACCOUNT
+
+statement ok
+CREATE SECRET s_private (
+    TYPE AZURE,
+    SCOPE 'azure://{AZ_STORAGE_ACCOUNT}.blob.core.windows.net/testing-private',
+    CONNECTION_STRING '{AZURE_STORAGE_CONNECTION_STRING}'
+)
+
+statement ok
+CREATE SECRET s_public (
+    TYPE AZURE,
+    SCOPE 'azure://{AZ_STORAGE_ACCOUNT}.blob.core.windows.net/testing-public',
+    CONNECTION_STRING '{AZURE_STORAGE_CONNECTION_STRING}'
+)
+
+# Both scopes resolved in the same query: each path must use its own secret/client
+query I
+SELECT (SELECT count(*) FROM 'azure://{AZ_STORAGE_ACCOUNT}.blob.core.windows.net/testing-private/lineitem.csv')
+     + (SELECT count(*) FROM 'azure://{AZ_STORAGE_ACCOUNT}.blob.core.windows.net/testing-public/lineitem.csv');
+----
+120350
+
+# Same thing, single scan over both containers
+query I
+SELECT count(*) FROM read_csv([
+    'azure://{AZ_STORAGE_ACCOUNT}.blob.core.windows.net/testing-private/lineitem.csv',
+    'azure://{AZ_STORAGE_ACCOUNT}.blob.core.windows.net/testing-public/lineitem.csv'
+]);
+----
+120350
+
+statement ok
+DROP SECRET s_private
+
+statement ok
+DROP SECRET s_public


### PR DESCRIPTION
## Problem

Reading Iceberg tables attached through a REST catalog with credential vending (e.g. Databricks Unity Catalog) intermittently fails with:

```
IO Error: AzureStorageFileSystem open file 'abfss://.../metadata/xxx-m0.avro' failed with code
'NoAuthenticationInformation', Reason Phrase: 'Server failed to authenticate the request. ...'
```

`NoAuthenticationInformation` means the request reached Azure without an `Authorization` header: no azure secret matched the path, so the extension silently created an **anonymous** client. With an instrumented build we confirmed the secret *did* exist with a scope covering the failing path — the lookup missed it, and an enumeration of the secret manager microseconds later saw it.

## Root cause

Three issues compound into the intermittent failure:

1. `LookupSecret` returns "no secret" whenever the `FileOpener` cannot provide a secret manager or a catalog transaction. Openers coming from scan threads can expose a `ClientContext` but no `DatabaseInstance`, in which case `FileOpener::TryGetSecretManager` returns nothing and the DFS path silently connects anonymously.
2. Catalog extensions register temporary (vended) secrets while scan threads are already opening files. A just-created catalog entry is stamped with the creator's `transaction_id` and only becomes visible to other transactions once it commits (`CatalogSet::CreateEntry` / `GetEntryForTransaction`), so there is a short window in which a lookup misses a secret that covers the path.
3. The storage-context cache (`GetOrCreateStorageContext`) is keyed by storage account only. Once an anonymous client is cached, every subsequent open of the same account in that query reuses it — `registered_state->Insert` does not replace existing entries — so a single miss poisons the whole query. This also means two secrets vended for different containers/tables of the same account share one client.

## Changes

- `LookupSecret`: when the opener cannot provide a secret manager/transaction directly, derive them from the `ClientContext` so temporary secrets are still found.
- Retry the lookup briefly (10/25/50/100 ms backoff, only when a secret manager is reachable) before falling back to an anonymous client, closing the registration/visibility window.
- Include the credential identity (`secret_name/provider` or `anonymous`) in the storage-context cache key so clients created under different credentials for the same storage account are never mixed.
- When a request from an anonymous client fails with 401/403, the error now states that no azure secret matched the path and suggests checking secret scopes, making this failure mode diagnosable.

## Testing

- Builds cleanly; existing tests unaffected (no test asserts the old error text).
- New test `test/sql/azure_secret_per_credential_cache.test`: two secrets scoped to different containers of the same storage account used within a single query (exercises the per-credential cache key). Follows the existing Azurite conventions.
- Validated on a production workload (hourly ETL reading Unity Catalog Iceberg tables over `abfss://`) that previously hit `NoAuthenticationInformation` several times a day: no failures since deploying a build with these changes.

The last report in #71 (Polaris catalog, 1.5.4) looks like it could be the same failure mode.

Related: when this error fires inside iceberg manifest-read tasks, it currently aborts the whole process instead of failing the query — addressed separately in duckdb/duckdb-iceberg#1305.
