### PR TITLE
Apply CA bundle workaround to default transport

### DIFF
--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -356,6 +356,14 @@ static Azure::Core::Http::Policies::TransportOptions GetTransportOptions(const s
                                                                          const std::string &proxy_password) {
 	Azure::Core::Http::Policies::TransportOptions transport_options;
 	if (transport_option_type == "default") {
+#if !defined(_WIN32) && !defined(__APPLE__)
+		// On Linux, the transport the Azure SDK builds internally for "default" is curl-based but,
+		// unlike CreateCurlTransport() below, does not search common CA bundle locations. That leaves
+		// it relying on libcurl's compiled-in default path, which is RedHat-family only and missing on
+		// Debian/Ubuntu, causing "Problem with the SSL CA cert" for every request.
+		// https://github.com/duckdb/duckdb-azure/issues/185
+		transport_options.Transport = CreateCurlTransport(proxy, proxy_username, proxy_password);
+#else
 		if (!proxy.empty()) {
 			transport_options.HttpProxy = proxy;
 		}
@@ -367,6 +375,7 @@ static Azure::Core::Http::Policies::TransportOptions GetTransportOptions(const s
 		if (!proxy_password.empty()) {
 			transport_options.ProxyPassword = proxy_password;
 		}
+#endif
 	} else if (transport_option_type == "curl") {
 		transport_options.Transport = CreateCurlTransport(proxy, proxy_username, proxy_password);
 	} else {


### PR DESCRIPTION
## Summary

Fixes #185, which I filed after hitting this in production: a Homer (SIP capture) deployment on a Debian 13 Azure VM, writing to a real Azure Storage account over `az://`.

`GetTransportOptions()` already has a workaround for a known azure-sdk-for-cpp gap.
The code comment cites it directly: Azure/azure-sdk-for-cpp#4983, a feature request closed upstream as stale without a fix, and Azure/azure-sdk-for-cpp#4738, which shows the same resulting "Problem with the SSL CA cert" error.
`CreateCurlTransport()` searches several well-known distro-specific CA bundle paths and passes the match to curl explicitly via `CAInfo`, instead of relying on libcurl's compile-time default path, which can differ from the path on the machine actually running the binary.

That workaround was only reachable via the opt-in `azure_transport_option_type='curl'` setting.
The actual default, `azure_transport_option_type='default'` (what every user gets unless they've discovered and set that option), never went through `CreateCurlTransport()`.
It left the transport unspecified, so the Azure SDK built its own default curl-based transport with no CAInfo override, hitting the raw upstream bug directly.
In practice, every HTTPS request from a default-config extension failed on affected Linux distros with "Problem with the SSL CA cert", regardless of the auth method used (Managed Identity, connection string, etc.) — this is a TLS/transport issue, not a credentials one.

## Fix

Route `azure_transport_option_type='default'` through the same `CreateCurlTransport()` on Linux, so it benefits from the existing CA-bundle search.
Windows/macOS are untouched, since they don't hit this (WinHTTP uses the OS certificate store, and macOS's curl uses the Keychain rather than a flat bundle file).

## Test plan

Reproduced against the actual official artifact, not a local build — the official DuckDB v1.5.5 CLI (`v1.5.5 Variegata d8cdaa33fd`, matching my original environment exactly) with the `azure` extension installed from `extensions.duckdb.org`, run on a real Debian machine against a real `*.blob.core.windows.net` endpoint:

- [x] With the distro's CA bundle only present at a path outside libcurl's compiled-in default (reproducing the environment from #185), `azure_transport_option_type='default'` (the shipped default) fails with the exact reported error: `Problem with the SSL CA cert (path? access rights?)`.
- [x] The same binary, same broken CA-path setup, same query, with only `SET azure_transport_option_type='curl'` added — i.e. exercising the exact code path this PR now also wires up for `'default'` — connects successfully and gets a normal Azure HTTP-level response instead (`NoAuthenticationInformation`), confirming the fix resolves the failure.
- [x] Built this PR's change from source and confirmed it compiles cleanly and the extension loads.
