### PR TITLE
Apply patches from duckdb/duckdb

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -38,7 +38,7 @@ jobs:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
-      duckdb_version: main
+      duckdb_version: fc4002c6e36f1e2d17d7c5b1a604777d69238d2b
       ci_tools_version: main
       extension_name: azure
       # TODO: format_checks += ;tidy


### PR DESCRIPTION
This PR applies patches from duckdb/duckdb:

It also bumps the duckdb submodules and `.github/workflows/MainDistributionPipeline.yml` to v2.0.0.
